### PR TITLE
Update default Elemental version to 0.85

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ export INSTALLATION_DIR
 ###############################################################################
 
 # default to Elemental version 0.85
-ELEMVER ?= 0.84-p1
+ELEMVER ?= 0.85
 
 # override if command-line arg 'ELEMVER' has been specified
 ifeq ($(ELEMVER), 0.81)


### PR DESCRIPTION
The makefile comments as well as instructions seemed to indicate the default version should be 0.85, rather than 0.84-p1
